### PR TITLE
Changing teraform to terragrunt

### DIFF
--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -34,10 +34,10 @@ func createFile(path string) {
 
 func createDirIfNotExist(dir string) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		log.Printf("Creating directory for teraform: %v", dir)
+		log.Printf("Creating directory for terragrunt: %v", dir)
 		err = os.MkdirAll(dir, 0755)
 		if err != nil {
-			fmt.Printf("Unable to create directory for teraform: %v", dir)
+			fmt.Printf("Unable to create directory for terragrunt: %v", dir)
 			panic(err)
 		}
 	}

--- a/lib/files.go
+++ b/lib/files.go
@@ -47,10 +47,10 @@ func CheckFileExist(file string) bool {
 //CreateDirIfNotExist : create directory if directory does not exist
 func CreateDirIfNotExist(dir string) {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		log.Printf("Creating directory for teraform: %v", dir)
+		log.Printf("Creating directory for terragrunt: %v", dir)
 		err = os.MkdirAll(dir, 0755)
 		if err != nil {
-			fmt.Printf("Unable to create directory for teraform: %v", dir)
+			fmt.Printf("Unable to create directory for terragrunt: %v", dir)
 			panic(err)
 		}
 	}


### PR DESCRIPTION
A reference to terraform was left in the code, this has been updated. At least the one with wrong spelling `teraform`. 