### PR TITLE
show error message instead of failing early

### DIFF
--- a/lib/list_versions.go
+++ b/lib/list_versions.go
@@ -69,7 +69,7 @@ func GetAppList(appURL string, client *modal.Client) ([]string, []modal.Repo) {
 	applist, assets := getAppVersion(appURL, numPages, client)
 
 	if len(applist) == 0 {
-		log.Fatal("Unable to get release from repo ")
+		log.Println("No versions returned")
 		os.Exit(1)
 	}
 
@@ -204,14 +204,14 @@ func getAppBody(gruntURLPage string, ch chan<- *[]modal.Repo) {
 
 	body, readErr := ioutil.ReadAll(res.Body)
 	if readErr != nil {
-		log.Fatal("Unable to get release from repo ")
+		log.Println("Unable to get release from repo ", string(body))
 		log.Fatal(readErr)
 	}
 
 	var repo []modal.Repo
 	jsonErr := json.Unmarshal(body, &repo)
 	if jsonErr != nil {
-		log.Fatal("Unable to get release from repo ")
+		log.Println("Unable to get release from repo ", string(body))
 		log.Fatal(jsonErr)
 	}
 


### PR DESCRIPTION
`log.Fatal()` will print the error message then call `os.Exit(1)`. In
a few spots `log.Fatal()` was called twice causing the second
error to never be shown to the user
