### PR TITLE
Dont contact github if terragrunt version exists locally

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -1,226 +1,226 @@
 package lib
 
 import (
-        "fmt"
-        "log"
-        "os"
-        "os/user"
-        "regexp"
-        "runtime"
+	"fmt"
+	"log"
+	"os"
+	"os/user"
+	"regexp"
+	"runtime"
 
-        "github.com/warrensbox/tgswitch/modal"
+	"github.com/warrensbox/tgswitch/modal"
 )
 
 const (
-        gruntURL       = "https://github.com/gruntwork-io/terragrunt/releases/download/"
-        installFile    = "terragrunt"
-        installVersion = "terragrunt_"
-        installPath    = "/.terragrunt.versions/"
-        recentFile     = "RECENT"
+	gruntURL       = "https://github.com/gruntwork-io/terragrunt/releases/download/"
+	installFile    = "terragrunt"
+	installVersion = "terragrunt_"
+	installPath    = "/.terragrunt.versions/"
+	recentFile     = "RECENT"
 )
 
 var (
-        installLocation = "/tmp"
+	installLocation = "/tmp"
 )
 
 // initialize : removes existing symlink to terragrunt binary
 func initialize() {
 
-        /* initilize default binary path for terraform */
-        /* assumes that terraform is installed here */
-        /* we will find the terraform path instalation later and replace this variable with the correct installed bin path */
-        installedBinPath := "/usr/local/bin/terragrunt"
+	/* initilize default binary path for terraform */
+	/* assumes that terraform is installed here */
+	/* we will find the terraform path instalation later and replace this variable with the correct installed bin path */
+	installedBinPath := "/usr/local/bin/terragrunt"
 
-        /* find terragrunt binary location if terragrunt is already installed*/
-        cmd := NewCommand("terragrunt")
-        next := cmd.Find()
+	/* find terragrunt binary location if terragrunt is already installed*/
+	cmd := NewCommand("terragrunt")
+	next := cmd.Find()
 
-        /* overrride installation default binary path if terragrunt is already installed */
-        /* find the last bin path */
-        for path := next(); len(path) > 0; path = next() {
-                installedBinPath = path
-        }
+	/* overrride installation default binary path if terragrunt is already installed */
+	/* find the last bin path */
+	for path := next(); len(path) > 0; path = next() {
+		installedBinPath = path
+	}
 
-        /* remove current symlink if exist*/
-        symlinkExist := CheckSymlink(installedBinPath)
+	/* remove current symlink if exist*/
+	symlinkExist := CheckSymlink(installedBinPath)
 
-        if symlinkExist {
-                RemoveSymlink(installedBinPath)
-        }
+	if symlinkExist {
+		RemoveSymlink(installedBinPath)
+	}
 }
 
 // GetInstallLocation : get location where the terraform binary will be installed,
 // will create a directory in the home location if it does not exist
 func GetInstallLocation() string {
-        /* get current user */
-        usr, errCurr := user.Current()
-        if errCurr != nil {
-                log.Fatal(errCurr)
-        }
-        /* set installation location */
-        installLocation = usr.HomeDir + installPath
-        /* Create local installation directory if it does not exist */
-        CreateDirIfNotExist(installLocation)
-        return installLocation
+	/* get current user */
+	usr, errCurr := user.Current()
+	if errCurr != nil {
+		log.Fatal(errCurr)
+	}
+	/* set installation location */
+	installLocation = usr.HomeDir + installPath
+	/* Create local installation directory if it does not exist */
+	CreateDirIfNotExist(installLocation)
+	return installLocation
 }
 
 //Install : Install the provided version in the argument
 func Install(url string, appversion string, assests []modal.Repo, installedBinPath string) string {
 
-        initialize()
-        installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
+	initialize()
+	installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 
-        /* If user provided bin path use user one instead of default */
-        // if userBinPath != nil {
-        //      installedBinPath = *userBinPath
-        // }
+	/* If user provided bin path use user one instead of default */
+	// if userBinPath != nil {
+	//      installedBinPath = *userBinPath
+	// }
 
-        pathDir := Path(installedBinPath)     //get path directory from binary path
-        binDirExist := CheckDirExist(pathDir) //check bin path exist
+	pathDir := Path(installedBinPath)     //get path directory from binary path
+	binDirExist := CheckDirExist(pathDir) //check bin path exist
 
-        if !binDirExist {
-                fmt.Printf("Binary path does not exist: %s\n", pathDir)
-                fmt.Printf("Please create binary path: %s for terragrunt installation\n", pathDir)
-                os.Exit(1)
-        }
+	if !binDirExist {
+		fmt.Printf("Binary path does not exist: %s\n", pathDir)
+		fmt.Printf("Please create binary path: %s for terragrunt installation\n", pathDir)
+		os.Exit(1)
+	}
 
-        /* check if selected version already downloaded */
-        fileExist := CheckFileExist(installLocation + installVersion + appversion)
-        if fileExist {
-                installLocation := ChangeSymlink(installedBinPath, appversion)
-                return installLocation
-        }
+	/* check if selected version already downloaded */
+	fileExist := CheckFileExist(installLocation + installVersion + appversion)
+	if fileExist {
+		installLocation := ChangeSymlink(installedBinPath, appversion)
+		return installLocation
+	}
 
-        /* remove current symlink if exist*/
-        symlinkExist := CheckSymlink(installedBinPath)
+	/* remove current symlink if exist*/
+	symlinkExist := CheckSymlink(installedBinPath)
 
-        if symlinkExist {
-                RemoveSymlink(installedBinPath)
-        }
+	if symlinkExist {
+		RemoveSymlink(installedBinPath)
+	}
 
-        /* if selected version already exist, */
-        /* proceed to download it from the terragrunt release page */
-        //url := gruntURL + "v" + tgversion + "/" + "terragrunt" + "_" + goos + "_" + goarch
+	/* if selected version already exist, */
+	/* proceed to download it from the terragrunt release page */
+	//url := gruntURL + "v" + tgversion + "/" + "terragrunt" + "_" + goos + "_" + goarch
 
-        goarch := runtime.GOARCH
-        goos := runtime.GOOS
-        urlDownload := ""
+	goarch := runtime.GOARCH
+	goos := runtime.GOOS
+	urlDownload := ""
 
-        for _, v := range assests {
+	for _, v := range assests {
 
-                if v.TagName == "v"+appversion {
-                        if len(v.Assets) > 0 {
-                                for _, b := range v.Assets {
+		if v.TagName == "v"+appversion {
+			if len(v.Assets) > 0 {
+				for _, b := range v.Assets {
 
-                                        matchedOS, _ := regexp.MatchString(goos, b.BrowserDownloadURL)
-                                        matchedARCH, _ := regexp.MatchString(goarch, b.BrowserDownloadURL)
-                                        if matchedOS && matchedARCH {
-                                                urlDownload = b.BrowserDownloadURL
-                                                break
-                                        }
-                                }
-                        }
-                        break
-                }
-        }
+					matchedOS, _ := regexp.MatchString(goos, b.BrowserDownloadURL)
+					matchedARCH, _ := regexp.MatchString(goarch, b.BrowserDownloadURL)
+					if matchedOS && matchedARCH {
+						urlDownload = b.BrowserDownloadURL
+						break
+					}
+				}
+			}
+			break
+		}
+	}
 
-        fileInstalled, _ := DownloadFromURL(installLocation, urlDownload)
+	fileInstalled, _ := DownloadFromURL(installLocation, urlDownload)
 
-        /* rename file to terragrunt version name - terragrunt_x.x.x */
-        RenameFile(fileInstalled, installLocation+installVersion+appversion)
+	/* rename file to terragrunt version name - terragrunt_x.x.x */
+	RenameFile(fileInstalled, installLocation+installVersion+appversion)
 
-        err := os.Chmod(installLocation+installVersion+appversion, 0755)
-        if err != nil {
-                log.Println(err)
-        }
+	err := os.Chmod(installLocation+installVersion+appversion, 0755)
+	if err != nil {
+		log.Println(err)
+	}
 
-        /* set symlink to desired version */
-        CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
-        fmt.Printf("Switched terragrunt to version %q \n", appversion)
-        return installLocation
+	/* set symlink to desired version */
+	CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
+	fmt.Printf("Switched terragrunt to version %q \n", appversion)
+	return installLocation
 }
 
 // AddRecent : add to recent file
 func AddRecent(requestedVersion string, installLocation string) {
 
-        installLocation = GetInstallLocation()
+	installLocation = GetInstallLocation()
 
-        semverRegex := regexp.MustCompile(`\d+(\.\d+){2}\z`)
+	semverRegex := regexp.MustCompile(`\d+(\.\d+){2}\z`)
 
-        fileExist := CheckFileExist(installLocation + recentFile)
-        if fileExist {
-                lines, errRead := ReadLines(installLocation + recentFile)
+	fileExist := CheckFileExist(installLocation + recentFile)
+	if fileExist {
+		lines, errRead := ReadLines(installLocation + recentFile)
 
-                if errRead != nil {
-                        fmt.Printf("Error: %s\n", errRead)
-                        return
-                }
+		if errRead != nil {
+			fmt.Printf("Error: %s\n", errRead)
+			return
+		}
 
-                for _, line := range lines {
-                        if !semverRegex.MatchString(line) {
-                                RemoveFiles(installLocation + recentFile)
-                                CreateRecentFile(requestedVersion)
-                                return
-                        }
-                }
+		for _, line := range lines {
+			if !semverRegex.MatchString(line) {
+				RemoveFiles(installLocation + recentFile)
+				CreateRecentFile(requestedVersion)
+				return
+			}
+		}
 
-                versionExist := VersionExist(requestedVersion, lines)
+		versionExist := VersionExist(requestedVersion, lines)
 
-                if !versionExist {
-                        if len(lines) >= 3 {
-                                _, lines = lines[len(lines)-1], lines[:len(lines)-1]
+		if !versionExist {
+			if len(lines) >= 3 {
+				_, lines = lines[len(lines)-1], lines[:len(lines)-1]
 
-                                lines = append([]string{requestedVersion}, lines...)
-                                WriteLines(lines, installLocation+recentFile)
-                        } else {
-                                lines = append([]string{requestedVersion}, lines...)
-                                WriteLines(lines, installLocation+recentFile)
-                        }
-                }
+				lines = append([]string{requestedVersion}, lines...)
+				WriteLines(lines, installLocation+recentFile)
+			} else {
+				lines = append([]string{requestedVersion}, lines...)
+				WriteLines(lines, installLocation+recentFile)
+			}
+		}
 
-        } else {
-                CreateRecentFile(requestedVersion)
-        }
+	} else {
+		CreateRecentFile(requestedVersion)
+	}
 }
 
 // GetRecentVersions : get recent version from file
 func GetRecentVersions() ([]string, error) {
 
-        installLocation = GetInstallLocation()
+	installLocation = GetInstallLocation()
 
-        fileExist := CheckFileExist(installLocation + recentFile)
-        if fileExist {
-                semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
+	fileExist := CheckFileExist(installLocation + recentFile)
+	if fileExist {
+		semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
 
-                lines, errRead := ReadLines(installLocation + recentFile)
-                outputRecent := []string{}
+		lines, errRead := ReadLines(installLocation + recentFile)
+		outputRecent := []string{}
 
-                if errRead != nil {
-                        fmt.Printf("Error: %s\n", errRead)
-                        return nil, errRead
-                }
+		if errRead != nil {
+			fmt.Printf("Error: %s\n", errRead)
+			return nil, errRead
+		}
 
-                for _, line := range lines {
-                        if !semverRegex.MatchString(line) {
-                                RemoveFiles(installLocation + recentFile)
-                                return nil, errRead
-                        }
+		for _, line := range lines {
+			if !semverRegex.MatchString(line) {
+				RemoveFiles(installLocation + recentFile)
+				return nil, errRead
+			}
 
-                        /*      output can be confusing since it displays the 3 most recent used terraform version
-                        append the string *recent to the output to make it more user friendly
-                        */
-                        outputRecent = append(outputRecent, fmt.Sprintf("%s *recent", line))
-                }
-                return outputRecent, nil
-        }
-        return nil, nil
+			/*      output can be confusing since it displays the 3 most recent used terraform version
+			append the string *recent to the output to make it more user friendly
+			*/
+			outputRecent = append(outputRecent, fmt.Sprintf("%s *recent", line))
+		}
+		return outputRecent, nil
+	}
+	return nil, nil
 }
 
 //CreateRecentFile : create a recent file
 func CreateRecentFile(requestedVersion string) {
 
-        installLocation = GetInstallLocation()
-        WriteLines([]string{requestedVersion}, installLocation+recentFile)
+	installLocation = GetInstallLocation()
+	WriteLines([]string{requestedVersion}, installLocation+recentFile)
 }
 
 // ValidVersionFormat : returns valid version format
@@ -232,10 +232,10 @@ func CreateRecentFile(requestedVersion string) {
 */
 func ValidVersionFormat(version string) bool {
 
-        // Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
-        // Follow https://semver.org/spec/v1.0.0-beta.html
-        // Check regular expression at https://rubular.com/r/ju3PxbaSBALpJB
-        semverRegex := regexp.MustCompile(`^(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?$`)
+	// Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
+	// Follow https://semver.org/spec/v1.0.0-beta.html
+	// Check regular expression at https://rubular.com/r/ju3PxbaSBALpJB
+	semverRegex := regexp.MustCompile(`^(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?$`)
 
-        return semverRegex.MatchString(version)
+	return semverRegex.MatchString(version)
 }

--- a/lib/install.go
+++ b/lib/install.go
@@ -1,237 +1,226 @@
 package lib
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"os/user"
-	"regexp"
-	"runtime"
+        "fmt"
+        "log"
+        "os"
+        "os/user"
+        "regexp"
+        "runtime"
 
-	"github.com/warrensbox/tgswitch/modal"
+        "github.com/warrensbox/tgswitch/modal"
 )
 
 const (
-	gruntURL       = "https://github.com/gruntwork-io/terragrunt/releases/download/"
-	installFile    = "terragrunt"
-	installVersion = "terragrunt_"
-	installPath    = "/.terragrunt.versions/"
-	recentFile     = "RECENT"
+        gruntURL       = "https://github.com/gruntwork-io/terragrunt/releases/download/"
+        installFile    = "terragrunt"
+        installVersion = "terragrunt_"
+        installPath    = "/.terragrunt.versions/"
+        recentFile     = "RECENT"
 )
 
 var (
-	installLocation = "/tmp"
+        installLocation = "/tmp"
 )
 
 // initialize : removes existing symlink to terragrunt binary
 func initialize() {
 
-	/* initilize default binary path for terraform */
-	/* assumes that terraform is installed here */
-	/* we will find the terraform path instalation later and replace this variable with the correct installed bin path */
-	installedBinPath := "/usr/local/bin/terragrunt"
+        /* initilize default binary path for terraform */
+        /* assumes that terraform is installed here */
+        /* we will find the terraform path instalation later and replace this variable with the correct installed bin path */
+        installedBinPath := "/usr/local/bin/terragrunt"
 
-	/* find terragrunt binary location if terragrunt is already installed*/
-	cmd := NewCommand("terragrunt")
-	next := cmd.Find()
+        /* find terragrunt binary location if terragrunt is already installed*/
+        cmd := NewCommand("terragrunt")
+        next := cmd.Find()
 
-	/* overrride installation default binary path if terragrunt is already installed */
-	/* find the last bin path */
-	for path := next(); len(path) > 0; path = next() {
-		installedBinPath = path
-	}
+        /* overrride installation default binary path if terragrunt is already installed */
+        /* find the last bin path */
+        for path := next(); len(path) > 0; path = next() {
+                installedBinPath = path
+        }
 
-	/* remove current symlink if exist*/
-	symlinkExist := CheckSymlink(installedBinPath)
+        /* remove current symlink if exist*/
+        symlinkExist := CheckSymlink(installedBinPath)
 
-	if symlinkExist {
-		RemoveSymlink(installedBinPath)
-	}
+        if symlinkExist {
+                RemoveSymlink(installedBinPath)
+        }
 }
 
-// getInstallLocation : get location where the terraform binary will be installed,
+// GetInstallLocation : get location where the terraform binary will be installed,
 // will create a directory in the home location if it does not exist
-func getInstallLocation() string {
-	/* get current user */
-	usr, errCurr := user.Current()
-	if errCurr != nil {
-		log.Fatal(errCurr)
-	}
-	/* set installation location */
-	installLocation = usr.HomeDir + installPath
-	/* Create local installation directory if it does not exist */
-	CreateDirIfNotExist(installLocation)
-	return installLocation
+func GetInstallLocation() string {
+        /* get current user */
+        usr, errCurr := user.Current()
+        if errCurr != nil {
+                log.Fatal(errCurr)
+        }
+        /* set installation location */
+        installLocation = usr.HomeDir + installPath
+        /* Create local installation directory if it does not exist */
+        CreateDirIfNotExist(installLocation)
+        return installLocation
 }
 
 //Install : Install the provided version in the argument
 func Install(url string, appversion string, assests []modal.Repo, installedBinPath string) string {
 
-	initialize()
-	installLocation = getInstallLocation() //get installation location -  this is where we will put our terraform binary file
+        initialize()
+        installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 
-	/* If user provided bin path use user one instead of default */
-	// if userBinPath != nil {
-	// 	installedBinPath = *userBinPath
-	// }
+        /* If user provided bin path use user one instead of default */
+        // if userBinPath != nil {
+        //      installedBinPath = *userBinPath
+        // }
 
-	pathDir := Path(installedBinPath)     //get path directory from binary path
-	binDirExist := CheckDirExist(pathDir) //check bin path exist
+        pathDir := Path(installedBinPath)     //get path directory from binary path
+        binDirExist := CheckDirExist(pathDir) //check bin path exist
 
-	if !binDirExist {
-		fmt.Printf("Binary path does not exist: %s\n", pathDir)
-		fmt.Printf("Please create binary path: %s for terragrunt installation\n", pathDir)
-		os.Exit(1)
-	}
+        if !binDirExist {
+                fmt.Printf("Binary path does not exist: %s\n", pathDir)
+                fmt.Printf("Please create binary path: %s for terragrunt installation\n", pathDir)
+                os.Exit(1)
+        }
 
-	/* check if selected version already downloaded */
-	fileExist := CheckFileExist(installLocation + installVersion + appversion)
+        /* check if selected version already downloaded */
+        fileExist := CheckFileExist(installLocation + installVersion + appversion)
+        if fileExist {
+                installLocation := ChangeSymlink(installedBinPath, appversion)
+                return installLocation
+        }
 
-	/* if selected version already exist, */
-	if fileExist {
+        /* remove current symlink if exist*/
+        symlinkExist := CheckSymlink(installedBinPath)
 
-		/* remove current symlink if exist*/
-		symlinkExist := CheckSymlink(installedBinPath)
+        if symlinkExist {
+                RemoveSymlink(installedBinPath)
+        }
 
-		if symlinkExist {
-			RemoveSymlink(installedBinPath)
-		}
-		/* set symlink to desired version */
-		CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
-		fmt.Printf("Switched terragrunt to version %q \n", appversion)
-		return installLocation
-	}
+        /* if selected version already exist, */
+        /* proceed to download it from the terragrunt release page */
+        //url := gruntURL + "v" + tgversion + "/" + "terragrunt" + "_" + goos + "_" + goarch
 
-	/* remove current symlink if exist*/
-	symlinkExist := CheckSymlink(installedBinPath)
+        goarch := runtime.GOARCH
+        goos := runtime.GOOS
+        urlDownload := ""
 
-	if symlinkExist {
-		RemoveSymlink(installedBinPath)
-	}
+        for _, v := range assests {
 
-	/* if selected version already exist, */
-	/* proceed to download it from the terragrunt release page */
-	//url := gruntURL + "v" + tgversion + "/" + "terragrunt" + "_" + goos + "_" + goarch
+                if v.TagName == "v"+appversion {
+                        if len(v.Assets) > 0 {
+                                for _, b := range v.Assets {
 
-	goarch := runtime.GOARCH
-	goos := runtime.GOOS
-	urlDownload := ""
+                                        matchedOS, _ := regexp.MatchString(goos, b.BrowserDownloadURL)
+                                        matchedARCH, _ := regexp.MatchString(goarch, b.BrowserDownloadURL)
+                                        if matchedOS && matchedARCH {
+                                                urlDownload = b.BrowserDownloadURL
+                                                break
+                                        }
+                                }
+                        }
+                        break
+                }
+        }
 
-	for _, v := range assests {
+        fileInstalled, _ := DownloadFromURL(installLocation, urlDownload)
 
-		if v.TagName == "v"+appversion {
-			if len(v.Assets) > 0 {
-				for _, b := range v.Assets {
+        /* rename file to terragrunt version name - terragrunt_x.x.x */
+        RenameFile(fileInstalled, installLocation+installVersion+appversion)
 
-					matchedOS, _ := regexp.MatchString(goos, b.BrowserDownloadURL)
-					matchedARCH, _ := regexp.MatchString(goarch, b.BrowserDownloadURL)
-					if matchedOS && matchedARCH {
-						urlDownload = b.BrowserDownloadURL
-						break
-					}
-				}
-			}
-			break
-		}
-	}
+        err := os.Chmod(installLocation+installVersion+appversion, 0755)
+        if err != nil {
+                log.Println(err)
+        }
 
-	fileInstalled, _ := DownloadFromURL(installLocation, urlDownload)
-
-	/* rename file to terragrunt version name - terragrunt_x.x.x */
-	RenameFile(fileInstalled, installLocation+installVersion+appversion)
-
-	err := os.Chmod(installLocation+installVersion+appversion, 0755)
-	if err != nil {
-		log.Println(err)
-	}
-
-	/* set symlink to desired version */
-	CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
-	fmt.Printf("Switched terragrunt to version %q \n", appversion)
-	return installLocation
+        /* set symlink to desired version */
+        CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
+        fmt.Printf("Switched terragrunt to version %q \n", appversion)
+        return installLocation
 }
 
 // AddRecent : add to recent file
 func AddRecent(requestedVersion string, installLocation string) {
 
-	installLocation = getInstallLocation()
+        installLocation = GetInstallLocation()
 
-	semverRegex := regexp.MustCompile(`\d+(\.\d+){2}\z`)
+        semverRegex := regexp.MustCompile(`\d+(\.\d+){2}\z`)
 
-	fileExist := CheckFileExist(installLocation + recentFile)
-	if fileExist {
-		lines, errRead := ReadLines(installLocation + recentFile)
+        fileExist := CheckFileExist(installLocation + recentFile)
+        if fileExist {
+                lines, errRead := ReadLines(installLocation + recentFile)
 
-		if errRead != nil {
-			fmt.Printf("Error: %s\n", errRead)
-			return
-		}
+                if errRead != nil {
+                        fmt.Printf("Error: %s\n", errRead)
+                        return
+                }
 
-		for _, line := range lines {
-			if !semverRegex.MatchString(line) {
-				RemoveFiles(installLocation + recentFile)
-				CreateRecentFile(requestedVersion)
-				return
-			}
-		}
+                for _, line := range lines {
+                        if !semverRegex.MatchString(line) {
+                                RemoveFiles(installLocation + recentFile)
+                                CreateRecentFile(requestedVersion)
+                                return
+                        }
+                }
 
-		versionExist := VersionExist(requestedVersion, lines)
+                versionExist := VersionExist(requestedVersion, lines)
 
-		if !versionExist {
-			if len(lines) >= 3 {
-				_, lines = lines[len(lines)-1], lines[:len(lines)-1]
+                if !versionExist {
+                        if len(lines) >= 3 {
+                                _, lines = lines[len(lines)-1], lines[:len(lines)-1]
 
-				lines = append([]string{requestedVersion}, lines...)
-				WriteLines(lines, installLocation+recentFile)
-			} else {
-				lines = append([]string{requestedVersion}, lines...)
-				WriteLines(lines, installLocation+recentFile)
-			}
-		}
+                                lines = append([]string{requestedVersion}, lines...)
+                                WriteLines(lines, installLocation+recentFile)
+                        } else {
+                                lines = append([]string{requestedVersion}, lines...)
+                                WriteLines(lines, installLocation+recentFile)
+                        }
+                }
 
-	} else {
-		CreateRecentFile(requestedVersion)
-	}
+        } else {
+                CreateRecentFile(requestedVersion)
+        }
 }
 
 // GetRecentVersions : get recent version from file
 func GetRecentVersions() ([]string, error) {
 
-	installLocation = getInstallLocation()
+        installLocation = GetInstallLocation()
 
-	fileExist := CheckFileExist(installLocation + recentFile)
-	if fileExist {
-		semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
+        fileExist := CheckFileExist(installLocation + recentFile)
+        if fileExist {
+                semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
 
-		lines, errRead := ReadLines(installLocation + recentFile)
-		outputRecent := []string{}
+                lines, errRead := ReadLines(installLocation + recentFile)
+                outputRecent := []string{}
 
-		if errRead != nil {
-			fmt.Printf("Error: %s\n", errRead)
-			return nil, errRead
-		}
+                if errRead != nil {
+                        fmt.Printf("Error: %s\n", errRead)
+                        return nil, errRead
+                }
 
-		for _, line := range lines {
-			if !semverRegex.MatchString(line) {
-				RemoveFiles(installLocation + recentFile)
-				return nil, errRead
-			}
+                for _, line := range lines {
+                        if !semverRegex.MatchString(line) {
+                                RemoveFiles(installLocation + recentFile)
+                                return nil, errRead
+                        }
 
-			/* 	output can be confusing since it displays the 3 most recent used terraform version
-			append the string *recent to the output to make it more user friendly
-			*/
-			outputRecent = append(outputRecent, fmt.Sprintf("%s *recent", line))
-		}
-		return outputRecent, nil
-	}
-	return nil, nil
+                        /*      output can be confusing since it displays the 3 most recent used terraform version
+                        append the string *recent to the output to make it more user friendly
+                        */
+                        outputRecent = append(outputRecent, fmt.Sprintf("%s *recent", line))
+                }
+                return outputRecent, nil
+        }
+        return nil, nil
 }
 
 //CreateRecentFile : create a recent file
 func CreateRecentFile(requestedVersion string) {
 
-	installLocation = getInstallLocation()
-	WriteLines([]string{requestedVersion}, installLocation+recentFile)
+        installLocation = GetInstallLocation()
+        WriteLines([]string{requestedVersion}, installLocation+recentFile)
 }
 
 // ValidVersionFormat : returns valid version format
@@ -243,10 +232,10 @@ func CreateRecentFile(requestedVersion string) {
 */
 func ValidVersionFormat(version string) bool {
 
-	// Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
-	// Follow https://semver.org/spec/v1.0.0-beta.html
-	// Check regular expression at https://rubular.com/r/ju3PxbaSBALpJB
-	semverRegex := regexp.MustCompile(`^(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?$`)
+        // Getting versions from body; should return match /X.X.X-@/ where X is a number,@ is a word character between a-z or A-Z
+        // Follow https://semver.org/spec/v1.0.0-beta.html
+        // Check regular expression at https://rubular.com/r/ju3PxbaSBALpJB
+        semverRegex := regexp.MustCompile(`^(\d+\.\d+\.\d+)(-[a-zA-z]+\d*)?$`)
 
-	return semverRegex.MatchString(version)
+        return semverRegex.MatchString(version)
 }

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -1,84 +1,84 @@
 package lib
 
 import (
-        "fmt"
-        "log"
-        "os"
+	"fmt"
+	"log"
+	"os"
 )
 
 //CreateSymlink : create symlink
 //CreateSymlink : create symlink
 func CreateSymlink(cwd string, dir string) {
 
-        err := os.Symlink(cwd, dir)
-        if err != nil {
-                log.Fatalf(`
-                Unable to create new symlink.
-                Maybe symlink already exist. Try removing existing symlink manually.
-                Try running "unlink" to remove existing symlink.
-                If error persist, you may not have the permission to create a symlink at %s.
-                Error: %s
-                `, dir, err)
-                os.Exit(1)
-        }
+	err := os.Symlink(cwd, dir)
+	if err != nil {
+		log.Fatalf(`
+		Unable to create new symlink.
+		Maybe symlink already exist. Try removing existing symlink manually.
+		Try running "unlink" to remove existing symlink.
+		If error persist, you may not have the permission to create a symlink at %s.
+		Error: %s
+		`, dir, err)
+		os.Exit(1)
+	}
 }
 
 //RemoveSymlink : remove symlink
 func RemoveSymlink(symlinkPath string) {
 
-        _, err := os.Lstat(symlinkPath)
-        if err != nil {
-                log.Fatalf(`
-                Unable to remove symlink.
-                Maybe symlink already exist. Try removing existing symlink manually.
-                Try running "unlink" to remove existing symlink.
-                If error persist, you may not have the permission to create a symlink at %s.
-                Error: %s
-                `, symlinkPath, err)
-                os.Exit(1)
-        } else {
-                errRemove := os.Remove(symlinkPath)
-                if errRemove != nil {
-                        log.Fatalf(`
-                        Unable to remove symlink.
-                        Maybe symlink already exist. Try removing existing symlink manually.
-                        Try running "unlink" to remove existing symlink.
-                        If error persist, you may not have the permission to create a symlink at %s.
-                        Error: %s
-                        `, symlinkPath, errRemove)
-                        os.Exit(1)
-                }
-        }
+	_, err := os.Lstat(symlinkPath)
+	if err != nil {
+		log.Fatalf(`
+		Unable to remove symlink.
+		Maybe symlink already exist. Try removing existing symlink manually.
+		Try running "unlink" to remove existing symlink.
+		If error persist, you may not have the permission to create a symlink at %s.
+		Error: %s
+		`, symlinkPath, err)
+		os.Exit(1)
+	} else {
+		errRemove := os.Remove(symlinkPath)
+		if errRemove != nil {
+			log.Fatalf(`
+			Unable to remove symlink.
+			Maybe symlink already exist. Try removing existing symlink manually.
+			Try running "unlink" to remove existing symlink.
+			If error persist, you may not have the permission to create a symlink at %s.
+			Error: %s
+			`, symlinkPath, errRemove)
+			os.Exit(1)
+		}
+	}
 }
 
 // CheckSymlink : check file is symlink
 func CheckSymlink(symlinkPath string) bool {
 
-        fi, err := os.Lstat(symlinkPath)
-        if err != nil {
-                return false
-        }
+	fi, err := os.Lstat(symlinkPath)
+	if err != nil {
+		return false
+	}
 
-        if fi.Mode()&os.ModeSymlink != 0 {
-                return true
-        }
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
 
-        return false
+	return false
 }
 
 // ChangeSymlink : move symlink to existing binary
 func ChangeSymlink(installedBinPath string, appversion string) string {
 
-        installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
+	installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
 
-        /* remove current symlink if exist*/
-        symlinkExist := CheckSymlink(installedBinPath)
-        if symlinkExist {
-                RemoveSymlink(installedBinPath)
-        }
-        /* set symlink to desired version */
-        CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
-        fmt.Printf("Switched terragrunt to version %q \n", appversion)
-        return installLocation
+	/* remove current symlink if exist*/
+	symlinkExist := CheckSymlink(installedBinPath)
+	if symlinkExist {
+		RemoveSymlink(installedBinPath)
+	}
+	/* set symlink to desired version */
+	CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
+	fmt.Printf("Switched terragrunt to version %q \n", appversion)
+	return installLocation
 
 }

--- a/lib/symlink.go
+++ b/lib/symlink.go
@@ -1,66 +1,84 @@
 package lib
 
 import (
-	"log"
-	"os"
+        "fmt"
+        "log"
+        "os"
 )
 
 //CreateSymlink : create symlink
 //CreateSymlink : create symlink
 func CreateSymlink(cwd string, dir string) {
 
-	err := os.Symlink(cwd, dir)
-	if err != nil {
-		log.Fatalf(`
-		Unable to create new symlink.
-		Maybe symlink already exist. Try removing existing symlink manually.
-		Try running "unlink" to remove existing symlink.
-		If error persist, you may not have the permission to create a symlink at %s.
-		Error: %s
-		`, dir, err)
-		os.Exit(1)
-	}
+        err := os.Symlink(cwd, dir)
+        if err != nil {
+                log.Fatalf(`
+                Unable to create new symlink.
+                Maybe symlink already exist. Try removing existing symlink manually.
+                Try running "unlink" to remove existing symlink.
+                If error persist, you may not have the permission to create a symlink at %s.
+                Error: %s
+                `, dir, err)
+                os.Exit(1)
+        }
 }
 
 //RemoveSymlink : remove symlink
 func RemoveSymlink(symlinkPath string) {
 
-	_, err := os.Lstat(symlinkPath)
-	if err != nil {
-		log.Fatalf(`
-		Unable to remove symlink.
-		Maybe symlink already exist. Try removing existing symlink manually.
-		Try running "unlink" to remove existing symlink.
-		If error persist, you may not have the permission to create a symlink at %s.
-		Error: %s
-		`, symlinkPath, err)
-		os.Exit(1)
-	} else {
-		errRemove := os.Remove(symlinkPath)
-		if errRemove != nil {
-			log.Fatalf(`
-			Unable to remove symlink.
-			Maybe symlink already exist. Try removing existing symlink manually.
-			Try running "unlink" to remove existing symlink.
-			If error persist, you may not have the permission to create a symlink at %s.
-			Error: %s
-			`, symlinkPath, errRemove)
-			os.Exit(1)
-		}
-	}
+        _, err := os.Lstat(symlinkPath)
+        if err != nil {
+                log.Fatalf(`
+                Unable to remove symlink.
+                Maybe symlink already exist. Try removing existing symlink manually.
+                Try running "unlink" to remove existing symlink.
+                If error persist, you may not have the permission to create a symlink at %s.
+                Error: %s
+                `, symlinkPath, err)
+                os.Exit(1)
+        } else {
+                errRemove := os.Remove(symlinkPath)
+                if errRemove != nil {
+                        log.Fatalf(`
+                        Unable to remove symlink.
+                        Maybe symlink already exist. Try removing existing symlink manually.
+                        Try running "unlink" to remove existing symlink.
+                        If error persist, you may not have the permission to create a symlink at %s.
+                        Error: %s
+                        `, symlinkPath, errRemove)
+                        os.Exit(1)
+                }
+        }
 }
 
 // CheckSymlink : check file is symlink
 func CheckSymlink(symlinkPath string) bool {
 
-	fi, err := os.Lstat(symlinkPath)
-	if err != nil {
-		return false
-	}
+        fi, err := os.Lstat(symlinkPath)
+        if err != nil {
+                return false
+        }
 
-	if fi.Mode()&os.ModeSymlink != 0 {
-		return true
-	}
+        if fi.Mode()&os.ModeSymlink != 0 {
+                return true
+        }
 
-	return false
+        return false
+}
+
+// ChangeSymlink : move symlink to existing binary
+func ChangeSymlink(installedBinPath string, appversion string) string {
+
+        installLocation = GetInstallLocation() //get installation location -  this is where we will put our terraform binary file
+
+        /* remove current symlink if exist*/
+        symlinkExist := CheckSymlink(installedBinPath)
+        if symlinkExist {
+                RemoveSymlink(installedBinPath)
+        }
+        /* set symlink to desired version */
+        CreateSymlink(installLocation+installVersion+appversion, installedBinPath)
+        fmt.Printf("Switched terragrunt to version %q \n", appversion)
+        return installLocation
+
 }

--- a/main.go
+++ b/main.go
@@ -30,11 +30,11 @@ import (
 )
 
 const (
-        terragruntURL  = "https://api.github.com/repos/gruntwork-io/terragrunt/releases?"
-        defaultBin     = "/usr/local/bin/terragrunt" //default bin installation dir
-        rcFilename     = ".tgswitchrc"
-        tgvFilename    = ".terragrunt-version"
-        installVersion = "terragrunt_"
+	terragruntURL  = "https://api.github.com/repos/gruntwork-io/terragrunt/releases?"
+	defaultBin     = "/usr/local/bin/terragrunt" //default bin installation dir
+	rcFilename     = ".tgswitchrc"
+	tgvFilename    = ".terragrunt-version"
+	installVersion = "terragrunt_"
 )
 
 var version = "0.2.0\n"
@@ -44,144 +44,144 @@ var CLIENT_SECRET = "xxx"
 
 func main() {
 
-        var client modal.Client
+	var client modal.Client
 
-        client.ClientID = CLIENT_ID
-        client.ClientSecret = CLIENT_SECRET
+	client.ClientID = CLIENT_ID
+	client.ClientSecret = CLIENT_SECRET
 
-        custBinPath := getopt.StringLong("bin", 'b', defaultBin, "Custom binary path. For example: /Users/username/bin/terragrunt")
-        versionFlag := getopt.BoolLong("version", 'v', "displays the version of tgswitch")
-        helpFlag := getopt.BoolLong("help", 'h', "displays help message")
-        _ = versionFlag
+	custBinPath := getopt.StringLong("bin", 'b', defaultBin, "Custom binary path. For example: /Users/username/bin/terragrunt")
+	versionFlag := getopt.BoolLong("version", 'v', "displays the version of tgswitch")
+	helpFlag := getopt.BoolLong("help", 'h', "displays help message")
+	_ = versionFlag
 
-        getopt.Parse()
-        args := getopt.Args()
+	getopt.Parse()
+	args := getopt.Args()
 
-        dir, err := os.Getwd()
-        if err != nil {
-                log.Printf("Failed to get current directory %v\n", err)
-                os.Exit(1)
-        }
+	dir, err := os.Getwd()
+	if err != nil {
+		log.Printf("Failed to get current directory %v\n", err)
+		os.Exit(1)
+	}
 
-        tgvfile := dir + fmt.Sprintf("/%s", tgvFilename) //settings for .terragrunt-version file in current directory (tgenv compatible)
-        rcfile := dir + fmt.Sprintf("/%s", rcFilename)   //settings for .tgswitchrc file in current directory
+	tgvfile := dir + fmt.Sprintf("/%s", tgvFilename) //settings for .terragrunt-version file in current directory (tgenv compatible)
+	rcfile := dir + fmt.Sprintf("/%s", rcFilename)   //settings for .tgswitchrc file in current directory
 
-        if *versionFlag {
-                fmt.Printf("\nVersion: %v\n", version)
-        } else if *helpFlag {
-                usageMessage()
-        } else {
-                installLocation := lib.GetInstallLocation()
-                if _, err := os.Stat(rcfile); err == nil && len(args) == 0 { //if there is a .tgswitchrc file, and no commmand line arguments
-                        fmt.Printf("Reading required terragrunt version %s \n", rcFilename)
+	if *versionFlag {
+		fmt.Printf("\nVersion: %v\n", version)
+	} else if *helpFlag {
+		usageMessage()
+	} else {
+		installLocation := lib.GetInstallLocation()
+		if _, err := os.Stat(rcfile); err == nil && len(args) == 0 { //if there is a .tgswitchrc file, and no commmand line arguments
+			fmt.Printf("Reading required terragrunt version %s \n", rcFilename)
 
-                        fileContents, err := ioutil.ReadFile(rcfile)
-                        if err != nil {
-                                fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", rcFilename)
-                                fmt.Printf("Error: %s\n", err)
-                                os.Exit(1)
-                        }
-                        tgversion := strings.TrimSuffix(string(fileContents), "\n")
-                        fileExist := lib.CheckFileExist(installLocation + installVersion + tgversion)
-                        if fileExist {
-                                lib.ChangeSymlink(*custBinPath, string(tgversion))
-                                os.Exit(0)
-                        }
-                        _, assets := lib.GetAppList(terragruntURL, &client)
+			fileContents, err := ioutil.ReadFile(rcfile)
+			if err != nil {
+				fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", rcFilename)
+				fmt.Printf("Error: %s\n", err)
+				os.Exit(1)
+			}
+			tgversion := strings.TrimSuffix(string(fileContents), "\n")
+			fileExist := lib.CheckFileExist(installLocation + installVersion + tgversion)
+			if fileExist {
+				lib.ChangeSymlink(*custBinPath, string(tgversion))
+				os.Exit(0)
+			}
+			_, assets := lib.GetAppList(terragruntURL, &client)
 
-                        if lib.ValidVersionFormat(tgversion) { //check if version is correct
-                                lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
-                        } else {
-                                fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
-                                os.Exit(1)
-                        }
+			if lib.ValidVersionFormat(tgversion) { //check if version is correct
+				lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
+			} else {
+				fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
+				os.Exit(1)
+			}
 
-                } else if _, err := os.Stat(tgvfile); err == nil && len(args) == 0 {
-                        fmt.Printf("Reading required terragrunt version %s \n", tgvFilename)
+		} else if _, err := os.Stat(tgvfile); err == nil && len(args) == 0 {
+			fmt.Printf("Reading required terragrunt version %s \n", tgvFilename)
 
-                        fileContents, err := ioutil.ReadFile(tgvfile)
-                        if err != nil {
-                                fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", tgvFilename)
-                                fmt.Printf("Error: %s\n", err)
-                                os.Exit(1)
-                        }
-                        tgversion := strings.TrimSuffix(string(fileContents), "\n")
-                        fileExist := lib.CheckFileExist(installLocation + installVersion + string(tgversion))
-                        if fileExist {
-                                lib.ChangeSymlink(*custBinPath, string(tgversion))
-                                os.Exit(0)
-                        }
-                        _, assets := lib.GetAppList(terragruntURL, &client)
+			fileContents, err := ioutil.ReadFile(tgvfile)
+			if err != nil {
+				fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", tgvFilename)
+				fmt.Printf("Error: %s\n", err)
+				os.Exit(1)
+			}
+			tgversion := strings.TrimSuffix(string(fileContents), "\n")
+			fileExist := lib.CheckFileExist(installLocation + installVersion + string(tgversion))
+			if fileExist {
+				lib.ChangeSymlink(*custBinPath, string(tgversion))
+				os.Exit(0)
+			}
+			_, assets := lib.GetAppList(terragruntURL, &client)
 
-                        if lib.ValidVersionFormat(tgversion) { //check if version is correct
-                                lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
-                        } else {
-                                fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
-                                os.Exit(1)
-                        }
+			if lib.ValidVersionFormat(tgversion) { //check if version is correct
+				lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
+			} else {
+				fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
+				os.Exit(1)
+			}
 
-                } else if len(args) == 1 {
+		} else if len(args) == 1 {
 
-                        semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
-                        if semverRegex.MatchString(args[0]) {
-                                requestedVersion := args[0]
+			semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
+			if semverRegex.MatchString(args[0]) {
+				requestedVersion := args[0]
 
-                                fileExist := lib.CheckFileExist(installLocation + installVersion + string(requestedVersion))
-                                if fileExist {
-                                        lib.ChangeSymlink(*custBinPath, string(requestedVersion))
-                                        os.Exit(0)
-                                }
+				fileExist := lib.CheckFileExist(installLocation + installVersion + string(requestedVersion))
+				if fileExist {
+					lib.ChangeSymlink(*custBinPath, string(requestedVersion))
+					os.Exit(0)
+				}
 
-                                //check if version exist before downloading it
-                                tflist, assets := lib.GetAppList(terragruntURL, &client)
-                                exist := lib.VersionExist(requestedVersion, tflist)
+				//check if version exist before downloading it
+				tflist, assets := lib.GetAppList(terragruntURL, &client)
+				exist := lib.VersionExist(requestedVersion, tflist)
 
-                                if exist {
-                                        installLocation := lib.Install(terragruntURL, requestedVersion, assets, *custBinPath)
-                                        lib.AddRecent(requestedVersion, installLocation) //add to recent file for faster lookup
-                                } else {
-                                        fmt.Println("Not a valid terragrunt version")
-                                }
+				if exist {
+					installLocation := lib.Install(terragruntURL, requestedVersion, assets, *custBinPath)
+					lib.AddRecent(requestedVersion, installLocation) //add to recent file for faster lookup
+				} else {
+					fmt.Println("Not a valid terragrunt version")
+				}
 
-                        } else {
-                                fmt.Println("Not a valid terragrunt version")
-                                fmt.Println("Args must be a valid terragrunt version")
-                                usageMessage()
-                        }
+			} else {
+				fmt.Println("Not a valid terragrunt version")
+				fmt.Println("Args must be a valid terragrunt version")
+				usageMessage()
+			}
 
-                } else if len(args) == 0 {
+		} else if len(args) == 0 {
 
-                        tglist, assets := lib.GetAppList(terragruntURL, &client)
-                        recentVersions, _ := lib.GetRecentVersions() //get recent versions from RECENT file
-                        tglist = append(recentVersions, tglist...)   //append recent versions to the top of the list
-                        tglist = lib.RemoveDuplicateVersions(tglist) //remove duplicate version
+			tglist, assets := lib.GetAppList(terragruntURL, &client)
+			recentVersions, _ := lib.GetRecentVersions() //get recent versions from RECENT file
+			tglist = append(recentVersions, tglist...)   //append recent versions to the top of the list
+			tglist = lib.RemoveDuplicateVersions(tglist) //remove duplicate version
 
-                        /* prompt user to select version of terragrunt */
-                        prompt := promptui.Select{
-                                Label: "Select terragrunt version",
-                                Items: tglist,
-                        }
+			/* prompt user to select version of terragrunt */
+			prompt := promptui.Select{
+				Label: "Select terragrunt version",
+				Items: tglist,
+			}
 
-                        _, tgversion, errPrompt := prompt.Run()
-                        tgversion = strings.Trim(tgversion, " *recent")
+			_, tgversion, errPrompt := prompt.Run()
+			tgversion = strings.Trim(tgversion, " *recent")
 
-                        if errPrompt != nil {
-                                log.Printf("Prompt failed %v\n", errPrompt)
-                                os.Exit(1)
-                        }
+			if errPrompt != nil {
+				log.Printf("Prompt failed %v\n", errPrompt)
+				os.Exit(1)
+			}
 
-                        installLocation := lib.Install(terragruntURL, tgversion, assets, *custBinPath)
-                        lib.AddRecent(tgversion, installLocation) //add to recent file for faster lookup
-                        os.Exit(0)
-                } else {
-                        usageMessage()
-                }
-        }
+			installLocation := lib.Install(terragruntURL, tgversion, assets, *custBinPath)
+			lib.AddRecent(tgversion, installLocation) //add to recent file for faster lookup
+			os.Exit(0)
+		} else {
+			usageMessage()
+		}
+	}
 
 }
 
 func usageMessage() {
-        fmt.Print("\n\n")
-        getopt.PrintUsage(os.Stderr)
-        fmt.Println("Supply the terragrunt version as an argument, or choose from a menu")
+	fmt.Print("\n\n")
+	getopt.PrintUsage(os.Stderr)
+	fmt.Println("Supply the terragrunt version as an argument, or choose from a menu")
 }

--- a/main.go
+++ b/main.go
@@ -16,17 +16,17 @@ package main
  */
 
 import (
-        "fmt"
-        "io/ioutil"
-        "log"
-        "os"
-        "regexp"
-        "strings"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strings"
 
-        "github.com/manifoldco/promptui"
-        "github.com/pborman/getopt"
-        lib "github.com/warrensbox/tgswitch/lib"
-        "github.com/warrensbox/tgswitch/modal"
+	"github.com/manifoldco/promptui"
+	"github.com/pborman/getopt"
+	lib "github.com/warrensbox/tgswitch/lib"
+	"github.com/warrensbox/tgswitch/modal"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -16,24 +16,25 @@ package main
  */
 
 import (
-	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
-	"regexp"
-	"strings"
+        "fmt"
+        "io/ioutil"
+        "log"
+        "os"
+        "regexp"
+        "strings"
 
-	"github.com/manifoldco/promptui"
-	"github.com/pborman/getopt"
-	lib "github.com/warrensbox/tgswitch/lib"
-	"github.com/warrensbox/tgswitch/modal"
+        "github.com/manifoldco/promptui"
+        "github.com/pborman/getopt"
+        lib "github.com/warrensbox/tgswitch/lib"
+        "github.com/warrensbox/tgswitch/modal"
 )
 
 const (
-	terragruntURL = "https://api.github.com/repos/gruntwork-io/terragrunt/releases?"
-	defaultBin    = "/usr/local/bin/terragrunt" //default bin installation dir
-	rcFilename    = ".tgswitchrc"
-	tgvFilename   = ".terragrunt-version"
+        terragruntURL  = "https://api.github.com/repos/gruntwork-io/terragrunt/releases?"
+        defaultBin     = "/usr/local/bin/terragrunt" //default bin installation dir
+        rcFilename     = ".tgswitchrc"
+        tgvFilename    = ".terragrunt-version"
+        installVersion = "terragrunt_"
 )
 
 var version = "0.2.0\n"
@@ -43,128 +44,144 @@ var CLIENT_SECRET = "xxx"
 
 func main() {
 
-	var client modal.Client
+        var client modal.Client
 
-	client.ClientID = CLIENT_ID
-	client.ClientSecret = CLIENT_SECRET
+        client.ClientID = CLIENT_ID
+        client.ClientSecret = CLIENT_SECRET
 
-	custBinPath := getopt.StringLong("bin", 'b', defaultBin, "Custom binary path. For example: /Users/username/bin/terragrunt")
-	versionFlag := getopt.BoolLong("version", 'v', "displays the version of tgswitch")
-	helpFlag := getopt.BoolLong("help", 'h', "displays help message")
-	_ = versionFlag
+        custBinPath := getopt.StringLong("bin", 'b', defaultBin, "Custom binary path. For example: /Users/username/bin/terragrunt")
+        versionFlag := getopt.BoolLong("version", 'v', "displays the version of tgswitch")
+        helpFlag := getopt.BoolLong("help", 'h', "displays help message")
+        _ = versionFlag
 
-	getopt.Parse()
-	args := getopt.Args()
+        getopt.Parse()
+        args := getopt.Args()
 
-	dir, err := os.Getwd()
-	if err != nil {
-		log.Printf("Failed to get current directory %v\n", err)
-		os.Exit(1)
-	}
+        dir, err := os.Getwd()
+        if err != nil {
+                log.Printf("Failed to get current directory %v\n", err)
+                os.Exit(1)
+        }
 
-	tgvfile := dir + fmt.Sprintf("/%s", tgvFilename) //settings for .terragrunt-version file in current directory (tgenv compatible)
-	rcfile := dir + fmt.Sprintf("/%s", rcFilename)   //settings for .tgswitchrc file in current directory
+        tgvfile := dir + fmt.Sprintf("/%s", tgvFilename) //settings for .terragrunt-version file in current directory (tgenv compatible)
+        rcfile := dir + fmt.Sprintf("/%s", rcFilename)   //settings for .tgswitchrc file in current directory
 
-	if *versionFlag {
-		fmt.Printf("\nVersion: %v\n", version)
-	} else if *helpFlag {
-		usageMessage()
-	} else {
+        if *versionFlag {
+                fmt.Printf("\nVersion: %v\n", version)
+        } else if *helpFlag {
+                usageMessage()
+        } else {
+                installLocation := lib.GetInstallLocation()
+                if _, err := os.Stat(rcfile); err == nil && len(args) == 0 { //if there is a .tgswitchrc file, and no commmand line arguments
+                        fmt.Printf("Reading required terragrunt version %s \n", rcFilename)
 
-		if _, err := os.Stat(rcfile); err == nil && len(args) == 0 { //if there is a .tgswitchrc file, and no commmand line arguments
-			fmt.Printf("Reading required terragrunt version %s \n", rcFilename)
+                        fileContents, err := ioutil.ReadFile(rcfile)
+                        if err != nil {
+                                fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", rcFilename)
+                                fmt.Printf("Error: %s\n", err)
+                                os.Exit(1)
+                        }
+                        tgversion := strings.TrimSuffix(string(fileContents), "\n")
+                        fileExist := lib.CheckFileExist(installLocation + installVersion + tgversion)
+                        if fileExist {
+                                lib.ChangeSymlink(*custBinPath, string(tgversion))
+                                os.Exit(0)
+                        }
+                        _, assets := lib.GetAppList(terragruntURL, &client)
 
-			fileContents, err := ioutil.ReadFile(rcfile)
-			if err != nil {
-				fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", rcFilename)
-				fmt.Printf("Error: %s\n", err)
-				os.Exit(1)
-			}
-			tgversion := strings.TrimSuffix(string(fileContents), "\n")
-			_, assets := lib.GetAppList(terragruntURL, &client)
+                        if lib.ValidVersionFormat(tgversion) { //check if version is correct
+                                lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
+                        } else {
+                                fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
+                                os.Exit(1)
+                        }
 
-			if lib.ValidVersionFormat(tgversion) { //check if version is correct
-				lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
-			} else {
-				fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
-				os.Exit(1)
-			}
+                } else if _, err := os.Stat(tgvfile); err == nil && len(args) == 0 {
+                        fmt.Printf("Reading required terragrunt version %s \n", tgvFilename)
 
-		} else if _, err := os.Stat(tgvfile); err == nil && len(args) == 0 {
-			fmt.Printf("Reading required terragrunt version %s \n", tgvFilename)
+                        fileContents, err := ioutil.ReadFile(tgvfile)
+                        if err != nil {
+                                fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", tgvFilename)
+                                fmt.Printf("Error: %s\n", err)
+                                os.Exit(1)
+                        }
+                        tgversion := strings.TrimSuffix(string(fileContents), "\n")
+                        fileExist := lib.CheckFileExist(installLocation + installVersion + string(tgversion))
+                        if fileExist {
+                                lib.ChangeSymlink(*custBinPath, string(tgversion))
+                                os.Exit(0)
+                        }
+                        _, assets := lib.GetAppList(terragruntURL, &client)
 
-			fileContents, err := ioutil.ReadFile(tgvfile)
-			if err != nil {
-				fmt.Printf("Failed to read %s file. Follow the README.md instructions for setup. https://github.com/warrensbox/tgswitch/blob/master/README.md\n", tgvFilename)
-				fmt.Printf("Error: %s\n", err)
-				os.Exit(1)
-			}
-			tgversion := strings.TrimSuffix(string(fileContents), "\n")
-			_, assets := lib.GetAppList(terragruntURL, &client)
+                        if lib.ValidVersionFormat(tgversion) { //check if version is correct
+                                lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
+                        } else {
+                                fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
+                                os.Exit(1)
+                        }
 
-			if lib.ValidVersionFormat(tgversion) { //check if version is correct
-				lib.Install(terragruntURL, string(tgversion), assets, *custBinPath)
-			} else {
-				fmt.Println("Invalid terragrunt version format. Format should be #.#.# or #.#.#-@# where # is numbers and @ is word characters. For example, 0.11.7 and 0.11.9-beta1 are valid versions")
-				os.Exit(1)
-			}
+                } else if len(args) == 1 {
 
-		} else if len(args) == 1 {
+                        semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
+                        if semverRegex.MatchString(args[0]) {
+                                requestedVersion := args[0]
 
-			semverRegex := regexp.MustCompile(`\A\d+(\.\d+){2}\z`)
-			if semverRegex.MatchString(args[0]) {
-				requestedVersion := args[0]
+                                fileExist := lib.CheckFileExist(installLocation + installVersion + string(requestedVersion))
+                                if fileExist {
+                                        lib.ChangeSymlink(*custBinPath, string(requestedVersion))
+                                        os.Exit(0)
+                                }
 
-				//check if version exist before downloading it
-				tflist, assets := lib.GetAppList(terragruntURL, &client)
-				exist := lib.VersionExist(requestedVersion, tflist)
+                                //check if version exist before downloading it
+                                tflist, assets := lib.GetAppList(terragruntURL, &client)
+                                exist := lib.VersionExist(requestedVersion, tflist)
 
-				if exist {
-					installLocation := lib.Install(terragruntURL, requestedVersion, assets, *custBinPath)
-					lib.AddRecent(requestedVersion, installLocation) //add to recent file for faster lookup
-				} else {
-					fmt.Println("Not a valid terragrunt version")
-				}
+                                if exist {
+                                        installLocation := lib.Install(terragruntURL, requestedVersion, assets, *custBinPath)
+                                        lib.AddRecent(requestedVersion, installLocation) //add to recent file for faster lookup
+                                } else {
+                                        fmt.Println("Not a valid terragrunt version")
+                                }
 
-			} else {
-				fmt.Println("Not a valid terragrunt version")
-				fmt.Println("Args must be a valid terragrunt version")
-				usageMessage()
-			}
+                        } else {
+                                fmt.Println("Not a valid terragrunt version")
+                                fmt.Println("Args must be a valid terragrunt version")
+                                usageMessage()
+                        }
 
-		} else if len(args) == 0 {
+                } else if len(args) == 0 {
 
-			tglist, assets := lib.GetAppList(terragruntURL, &client)
-			recentVersions, _ := lib.GetRecentVersions() //get recent versions from RECENT file
-			tglist = append(recentVersions, tglist...)   //append recent versions to the top of the list
-			tglist = lib.RemoveDuplicateVersions(tglist) //remove duplicate version
+                        tglist, assets := lib.GetAppList(terragruntURL, &client)
+                        recentVersions, _ := lib.GetRecentVersions() //get recent versions from RECENT file
+                        tglist = append(recentVersions, tglist...)   //append recent versions to the top of the list
+                        tglist = lib.RemoveDuplicateVersions(tglist) //remove duplicate version
 
-			/* prompt user to select version of terragrunt */
-			prompt := promptui.Select{
-				Label: "Select terragrunt version",
-				Items: tglist,
-			}
+                        /* prompt user to select version of terragrunt */
+                        prompt := promptui.Select{
+                                Label: "Select terragrunt version",
+                                Items: tglist,
+                        }
 
-			_, tgversion, errPrompt := prompt.Run()
-			tgversion = strings.Trim(tgversion, " *recent")
+                        _, tgversion, errPrompt := prompt.Run()
+                        tgversion = strings.Trim(tgversion, " *recent")
 
-			if errPrompt != nil {
-				log.Printf("Prompt failed %v\n", errPrompt)
-				os.Exit(1)
-			}
+                        if errPrompt != nil {
+                                log.Printf("Prompt failed %v\n", errPrompt)
+                                os.Exit(1)
+                        }
 
-			installLocation := lib.Install(terragruntURL, tgversion, assets, *custBinPath)
-			lib.AddRecent(tgversion, installLocation) //add to recent file for faster lookup
-			os.Exit(0)
-		} else {
-			usageMessage()
-		}
-	}
+                        installLocation := lib.Install(terragruntURL, tgversion, assets, *custBinPath)
+                        lib.AddRecent(tgversion, installLocation) //add to recent file for faster lookup
+                        os.Exit(0)
+                } else {
+                        usageMessage()
+                }
+        }
 
 }
 
 func usageMessage() {
-	fmt.Print("\n\n")
-	getopt.PrintUsage(os.Stderr)
-	fmt.Println("Supply the terragrunt version as an argument, or choose from a menu")
+        fmt.Print("\n\n")
+        getopt.PrintUsage(os.Stderr)
+        fmt.Println("Supply the terragrunt version as an argument, or choose from a menu")
 }


### PR DESCRIPTION
These changes are to prevent tgswitch from going out to Github if the requested version of Terragrunt already exists in ~/.terragrunt.versions/. 