### PR TITLE
Feature: Make tgswitch working on windows

### DIFF
--- a/lib/install.go
+++ b/lib/install.go
@@ -259,10 +259,8 @@ func InstallableBinLocation(userBinPath string) string {
 
 	if binPathExist == true { //if bin path exist - check if we can write to to it
 
-		binPathWritable := false //assume bin path is not writable
-		if runtime.GOOS != "windows" {
-			binPathWritable = CheckDirWritable(binDir) //check if is writable on ( only works on LINUX)
-		}
+		binPathWritable := false                   //assume bin path is not writable
+		binPathWritable = CheckDirWritable(binDir) //check if is writable on ( only works on LINUX)
 
 		// IF: "/usr/local/bin" or `custom bin path` provided by user is non-writable, (binPathWritable == false), we will attempt to install terragrunt at the ~/bin location. See ELSE
 		if binPathWritable == false {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/hashicorp/hcl2/gohcl"
@@ -32,7 +33,6 @@ import (
 
 const (
 	terragruntURL = "https://github.com/gruntwork-io/terragrunt/releases/download/"
-	defaultBin    = "/usr/local/bin/terragrunt" //default bin installation dir
 	rcFilename    = ".tgswitchrc"
 	tgvFilename   = ".terragrunt-version"
 	versionPrefix = "terragrunt_"
@@ -40,6 +40,8 @@ const (
 	tomlFilename  = ".tgswitch.toml"
 	tgHclFilename = "terragrunt.hcl"
 )
+
+var defaultBin = getOSDefaultBin()
 
 var version = "0.5.0\n"
 
@@ -328,4 +330,18 @@ func checkVersionDefinedHCL(tgFile *string) bool {
 
 type terragruntVersionConstraints struct {
 	TerragruntVersionConstraint string `hcl:"terragrunt_version_constraint"`
+}
+
+func getOSDefaultBin() string {
+	//
+	const goos = runtime.GOOS
+	var homedir = lib.GetHomeDirectory()
+
+	if goos == "darwin" {
+		return homedir + "/bin/terragrunt"
+	}
+	if goos == "windows" {
+		return homedir + "/bin/terragrunt.exe"
+	}
+	return "/usr/local/bin/terragrunt"
 }


### PR DESCRIPTION
This PR makes tgswitch working on windows by changing default path. It also allows to have different default path on each OS.